### PR TITLE
removed broken as.data.frame() in b2AuthorizeAccount

### DIFF
--- a/R/b2AuthorizeAccount.R
+++ b/R/b2AuthorizeAccount.R
@@ -67,9 +67,9 @@ b2AuthorizeAccount <- function(url, accountId, authorizationKey) {
     )
 
   } else {
-    # Output as dataframe.
+    # Output as list
     accountAuthorization <-
-      as.data.frame(jsonlite::fromJSON(httr::content(b2Return, type = "text")))
+      jsonlite::fromJSON(httr::content(b2Return, type = "text"))
     # Set environment variables to save authorisation details
     Sys.setenv(apiUrl = accountAuthorization$apiUrl)
     Sys.setenv(accountId = accountAuthorization$accountId)


### PR DESCRIPTION
Coercing it to a data.frame fails. Keeping it as a list seems to work just fine though so it's a simple fix.