### PR TITLE
Update b2AuthorizeAccount.R

### DIFF
--- a/R/b2AuthorizeAccount.R
+++ b/R/b2AuthorizeAccount.R
@@ -23,11 +23,11 @@
 #' occurs. Don't login more than is necessary.
 #'
 #' @param url Specific API endpoint address for this function. See examples.
-#' @param accountId Account identification code for the relevant Backblaze B2
+#' @param keyID Account identification code for the relevant Backblaze B2
 #'   account. This may be obtained by clicking \emph{Show Account ID and
 #'   Application Key} hypertext from the B2 My Account area, after logging in
 #'   with a web browser.
-#' @param authorizationKey Account authorisation key for the relevant Backblaze
+#' @param applicationKey Account authorisation key for the relevant Backblaze
 #'   B2 account. This may be obtained by clicking \emph{Show Account ID and
 #'   Application Key} hypertext from the B2 My Account area, after logging in
 #'   with a web browser.
@@ -41,23 +41,22 @@
 #'
 #' @examples
 #' \dontrun{
-#' b2AuthorizeAccount(url = "https://api.backblaze.com/b2api/v1/b2_authorize_account",
+#' b2AuthorizeAccount(url = "https://api.backblaze.com/b2api/v3/b2_authorize_account",
 #' accountId = "YourAccountId",
 #' authorizationKey = "YourAuthorisationKey")
 #' }
 #'
 #' @export
 
-b2AuthorizeAccount <- function(url, accountId, authorizationKey) {
+b2AuthorizeAccount <- function(url, keyID, applicationKey) {
   # Combine Account Id and Authorisation Key
-  accessToken <- paste(accountId,":",authorizationKey, sep = "")
+  accessToken <- paste(keyID,":", applicationKey, sep = "")
   # Base 64 encode access token
   accessToken <- openssl::base64_encode(accessToken)
   # GET the data
   b2Return <-
-    httr::GET(url = url, httr::add_headers(Authorization = paste("Basic ", accessToken, sep =
-                                                                   "")))
-
+    httr::GET(url = url, httr::add_headers(Authorization = paste("Basic ", accessToken, sep = "")))
+  
   # Check for bad authorisation and sent message
   if (httr::status_code(b2Return) != "200") {
     badReturn <-
@@ -65,15 +64,14 @@ b2AuthorizeAccount <- function(url, accountId, authorizationKey) {
     stop(
       "Status Code: ", badReturn$code, "\n Message: ", badReturn$message, "\nPlease check your account ID and Authorisation Key. Remember, a new Authorisation key is generated every time you click 'Create application key' in the B2 web interface. \n"
     )
-
+    
   } else {
     # Output as dataframe.
-    accountAuthorization <-
-      as.data.frame(jsonlite::fromJSON(httr::content(b2Return, type = "text")))
+    accountAuthorization <-jsonlite::fromJSON(httr::content(b2Return, type = "text"))
     # Set environment variables to save authorisation details
-    Sys.setenv(apiUrl = accountAuthorization$apiUrl)
+    Sys.setenv(apiUrl = accountAuthorization$apiInfo$storageApi$apiUrl)
     Sys.setenv(accountId = accountAuthorization$accountId)
     Sys.setenv(authorizationToken = accountAuthorization$authorizationToken)
-    Sys.setenv(downloadUrl = accountAuthorization$downloadUrl)
+    Sys.setenv(downloadUrl = accountAuthorization$apiInfo$storageApi$downloadUrl)
   }
 }


### PR DESCRIPTION
It doesn't look this package has been updated in several years. I found that I couldn't get `b2AuthorizeAccount()` to work with the current version of the `b2` API without some small changes to the code.

This small PR:
- Renames function argument names to match those in Backblaze (accountID -> keyID, authorizationKey -> applicationKey)
- Pulls the right variable from the reponse, which has changed between v1 and v3
- Changes the API URL from v1 to v3